### PR TITLE
chore: auto-merge safe Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,58 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "17:00"
+      timezone: "Europe/Copenhagen"
+    # Groups are matched in order; first match wins. Majors stay ungrouped for review.
+    groups:
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+        update-types:
+          - "minor"
+          - "patch"
+      production-minor-and-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          # Framework upgrades are reviewed manually (never auto-merged).
+          - "astro"
+          - "@astrojs/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      development-minor-and-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Updated by the Update Node workflow
+      - dependency-name: "@types/node"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
     schedule:
       interval: "weekly"
       day: "friday"
       time: "17:00"
       timezone: "Europe/Copenhagen"
     groups:
-      tailwind:
+      github-actions-minor-and-patch:
         patterns:
-          - "tailwindcss"
-          - "@tailwindcss/vite"
-    ignore:
-      # Ignore updates for @types/node as they are updated in the Update Node workflow
-      - dependency-name: "@types/node"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    open-pull-requests-limit: 5
-    schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "17:00"
-      timezone: "Europe/Copenhagen"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,101 @@
+# Enables GitHub auto-merge for low-risk Dependabot PRs once required checks pass.
+#
+# Uses pull_request_target so GITHUB_TOKEN has write access for Dependabot PRs.
+# Do not checkout or execute PR code in this workflow.
+
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide merge eligibility
+        id: policy
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+        run: |
+          set -euo pipefail
+
+          echo "update-type=$UPDATE_TYPE"
+          echo "dependency-names=$DEPENDENCY_NAMES"
+          echo "dependency-group=$DEPENDENCY_GROUP"
+          echo "package-ecosystem=$PACKAGE_ECOSYSTEM"
+
+          eligible=true
+          reason=""
+
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch|version-update:semver-minor) ;;
+            *)
+              eligible=false
+              reason="update type is ${UPDATE_TYPE:-unknown} (only patch/minor auto-merge)"
+              ;;
+          esac
+
+          # Deny-list: framework packages — any mention blocks auto-merge.
+          if [ "$eligible" = true ]; then
+            IFS=',' read -r -a deps <<< "$DEPENDENCY_NAMES"
+            for dep in "${deps[@]}"; do
+              dep_trimmed="${dep#"${dep%%[![:space:]]*}"}"
+              dep_trimmed="${dep_trimmed%"${dep_trimmed##*[![:space:]]}"}"
+              if [ "$dep_trimmed" = "astro" ] || [[ "$dep_trimmed" == @astrojs/* ]]; then
+                eligible=false
+                reason="contains denied dependency: $dep_trimmed"
+                break
+              fi
+            done
+          fi
+
+          {
+            echo "eligible=$eligible"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.policy.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "dependencies" --add-label "automerge"
+          gh pr merge --auto --squash "$PR_URL"
+          echo "Enabled auto-merge (squash) for $PR_URL"
+
+      - name: Mark for manual review
+        if: steps.policy.outputs.eligible != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REASON: ${{ steps.policy.outputs.reason }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "dependencies" --add-label "needs-manual-review"
+          gh pr comment "$PR_URL" --body "$(cat <<EOF
+          ### Dependabot auto-merge skipped
+
+          This PR was **not** enrolled in auto-merge: ${REASON}.
+
+          Patch/minor updates outside the deny-list (\`astro\`, \`@astrojs/*\`) merge automatically once required checks pass. Majors and denied packages need a human (or a follow-up agent).
+          EOF
+          )"


### PR DESCRIPTION
## Summary
- Group Dependabot patch/minor updates (production, development, Tailwind, GitHub Actions) to cut weekly PR volume; leave majors and Astro packages ungrouped for review.
- Add a `pull_request_target` workflow that enables squash auto-merge for patch/minor Dependabot PRs outside the `astro` / `@astrojs/*` deny-list, and labels the rest for manual review.

## Test plan
- [x] Confirm repo has **Allow auto-merge** enabled and branch protection on `main` requires the usual CI checks.
- [x] Confirm labels exist: `dependencies`, `github-actions`, `automerge`, `needs-manual-review`.
- [x] After merge, open (or wait for) a patch/minor Dependabot PR and verify it gets `automerge` and auto-merges when checks are green.
- [x] Open (or identify) an Astro or major Dependabot PR and verify it gets `needs-manual-review` plus the skip comment, with no auto-merge.