### PR TITLE
fix(dependabot): scan composite actions and group all dev updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       timezone: "Europe/Copenhagen"
     # Groups are matched in order; first match wins.
     # Production majors stay ungrouped so each can be reviewed on its own.
+    # Development updates (including majors) are grouped together.
     groups:
       tailwind:
         patterns:
@@ -30,17 +31,18 @@ updates:
         exclude-patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
-      development-minor-and-patch:
+      development:
         dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
     ignore:
       # Updated by the Update Node workflow
       - dependency-name: "@types/node"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers workflows; "/.github/actions/*" covers local composite actions
+    # (Dependabot does not scan those under "/" alone).
+    directories:
+      - "/"
+      - "/.github/actions/*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- Scan `/.github/actions/*` so Dependabot updates actions used in local composite actions (`setup-node`, `pnpm/action-setup`).
- Rename the development group and drop the minor/patch-only filter so majors (e.g. `oxlint-tsgolint`) land in the same grouped PR.

## Test plan
- [ ] Confirm Dependabot config validates (GitHub Dependabot → Recent update jobs, or wait for next scheduled run)
- [ ] After next github-actions update job, expect PRs touching `.github/actions/setup/action.yml` for `actions/setup-node` / `pnpm/action-setup` majors
- [ ] After next npm update job, expect `oxlint-tsgolint` major to appear in the `development` group PR (reopen/recreate #387 if needed for the current version)